### PR TITLE
fhsEnv-shell: use clang version for fhsEnv-shell package

### DIFF
--- a/pkgs/fhsEnv-shell/default.nix
+++ b/pkgs/fhsEnv-shell/default.nix
@@ -6,7 +6,7 @@
  zlib,
  elfutils,
  pkgs,
- gcc,
+ clang,
  ncurses,
  bashInteractive,
  writeScript,
@@ -168,7 +168,8 @@ let
   };
 in stdenvNoCC.mkDerivation {
   pname = "fhsEnv-shell";
-  version = gcc.version;
+  ### Use clang version for fhsEnv-shell version
+  version = clang.version;
 
   ### stdenv options
   dontUnpack = true;


### PR DESCRIPTION
- **fhsEnv-shell: add gnum4 package**
- **fhsEnv-shell: use clang version for fhsEnv-shell package**
